### PR TITLE
Profile settings skeleton

### DIFF
--- a/client/public/index.html
+++ b/client/public/index.html
@@ -17,7 +17,10 @@
       href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700,800,900|Material+Icons"
     />
 
-    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;500;700;800;900" rel="stylesheet" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Poppins:wght@100;200;300;500;600;700;800;900"
+      rel="stylesheet"
+    />
     <!--
     Notice the use of %PUBLIC_URL% in the tags above.
     It will be replaced with the URL of the `public` folder during the build.

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -28,14 +28,13 @@ function App(): JSX.Element {
               <Switch>
                 <Route exact path="/login" component={Login} />
                 <Route exact path="/signup" component={Signup} />
-                <Route exact path="/dashboard">
-                  <Dashboard />
-                </Route>
-                <Route component={BecomeASitter} exact path="/become-a-sitter" />
-                <Route component={MySitters} exact path="/my-sitters" />
-                <Route component={MyJobs} exact path="/my-jobs" />
-                <Route component={Messages} exact path="/messages" />
-                <Route component={Profile} exact path="/profile" />
+                <Route exact path="/dashboard" component={Dashboard} />
+                <Route exact path="/become-a-sitter" component={BecomeASitter} />
+                <Route exact path="/my-sitters" component={MySitters} />
+                <Route exact path="/my-jobs" component={MyJobs} />
+                <Route exact path="/messages" component={Messages} />
+                <Route exact path="/profile" component={Profile} />
+                <Route path="/profile/:setting" component={Profile} />
                 <Route path="*">
                   <Redirect to="/login" />
                 </Route>

--- a/client/src/pages/Dashboard/profile/Profile.tsx
+++ b/client/src/pages/Dashboard/profile/Profile.tsx
@@ -1,24 +1,40 @@
-import Grid from '@material-ui/core/Grid';
-import CircularProgress from '@material-ui/core/CircularProgress';
-import { useAuth } from '../../../context/useAuthContext';
-import { useHistory } from 'react-router-dom';
+import { Box } from '@material-ui/core';
+import ProfileNav from './profileNav/ProfileNav';
+import EditProfile from './editProfile/EditProfile';
+import Payment from './payment/Payment';
+import { useLocation } from 'react-router-dom';
+import useStyles from './useStyles';
+import Settings from './settings/Settings';
+import Security from './security/Security';
+import ProfilePhoto from './profilePhoto/ProfilePhoto';
 
 export default function Profile(): JSX.Element {
-  const { loggedInUser } = useAuth();
-  const history = useHistory();
-
-  if (loggedInUser === undefined) return <CircularProgress />;
-  if (!loggedInUser) {
-    history.push('/login');
-    // loading for a split seconds until history.push works
-    return <CircularProgress />;
-  }
-
+  const location = useLocation();
+  const classes = useStyles();
+  const content = () => {
+    switch (location.pathname) {
+      case '/profile':
+        return <EditProfile />;
+      case '/profile/payment':
+        return <Payment />;
+      case '/profile/settings':
+        return <Settings />;
+      case '/profile/security':
+        return <Security />;
+      case '/profile/profile-photo':
+        return <ProfilePhoto />;
+      default:
+        break;
+    }
+  };
   return (
-    <Grid container component="main">
-      <Grid item>
-        <h2>Profile</h2>
-      </Grid>
-    </Grid>
+    <Box display="flex">
+      <ProfileNav />
+      <Box display="flex" className={classes.viewContainer}>
+        <Box display="flex" className={classes.contentContainer}>
+          {content()}
+        </Box>
+      </Box>
+    </Box>
   );
 }

--- a/client/src/pages/Dashboard/profile/editProfile/EditProfile.tsx
+++ b/client/src/pages/Dashboard/profile/editProfile/EditProfile.tsx
@@ -1,20 +1,6 @@
 import Grid from '@material-ui/core/Grid';
-import CircularProgress from '@material-ui/core/CircularProgress';
-import { useAuth } from '../../../../context/useAuthContext';
-import { useHistory } from 'react-router-dom';
 
 export default function EditProfile(): JSX.Element {
-  const { loggedInUser } = useAuth();
-
-  const history = useHistory();
-
-  if (loggedInUser === undefined) return <CircularProgress />;
-  if (!loggedInUser) {
-    history.push('/login');
-    // loading for a split seconds until history.push works
-    return <CircularProgress />;
-  }
-
   return (
     <Grid container component="main">
       <Grid item>

--- a/client/src/pages/Dashboard/profile/editProfile/EditProfile.tsx
+++ b/client/src/pages/Dashboard/profile/editProfile/EditProfile.tsx
@@ -1,0 +1,25 @@
+import Grid from '@material-ui/core/Grid';
+import CircularProgress from '@material-ui/core/CircularProgress';
+import { useAuth } from '../../../../context/useAuthContext';
+import { useHistory } from 'react-router-dom';
+
+export default function EditProfile(): JSX.Element {
+  const { loggedInUser } = useAuth();
+
+  const history = useHistory();
+
+  if (loggedInUser === undefined) return <CircularProgress />;
+  if (!loggedInUser) {
+    history.push('/login');
+    // loading for a split seconds until history.push works
+    return <CircularProgress />;
+  }
+
+  return (
+    <Grid container component="main">
+      <Grid item>
+        <h2>edit profile</h2>
+      </Grid>
+    </Grid>
+  );
+}

--- a/client/src/pages/Dashboard/profile/payment/Payment.tsx
+++ b/client/src/pages/Dashboard/profile/payment/Payment.tsx
@@ -1,0 +1,25 @@
+import Grid from '@material-ui/core/Grid';
+import CircularProgress from '@material-ui/core/CircularProgress';
+import { useAuth } from '../../../../context/useAuthContext';
+import { useHistory } from 'react-router-dom';
+
+export default function Payment(): JSX.Element {
+  const { loggedInUser } = useAuth();
+
+  const history = useHistory();
+
+  if (loggedInUser === undefined) return <CircularProgress />;
+  if (!loggedInUser) {
+    history.push('/login');
+    // loading for a split seconds until history.push works
+    return <CircularProgress />;
+  }
+
+  return (
+    <Grid container component="main">
+      <Grid item>
+        <h2>payment</h2>
+      </Grid>
+    </Grid>
+  );
+}

--- a/client/src/pages/Dashboard/profile/payment/Payment.tsx
+++ b/client/src/pages/Dashboard/profile/payment/Payment.tsx
@@ -1,20 +1,6 @@
 import Grid from '@material-ui/core/Grid';
-import CircularProgress from '@material-ui/core/CircularProgress';
-import { useAuth } from '../../../../context/useAuthContext';
-import { useHistory } from 'react-router-dom';
 
 export default function Payment(): JSX.Element {
-  const { loggedInUser } = useAuth();
-
-  const history = useHistory();
-
-  if (loggedInUser === undefined) return <CircularProgress />;
-  if (!loggedInUser) {
-    history.push('/login');
-    // loading for a split seconds until history.push works
-    return <CircularProgress />;
-  }
-
   return (
     <Grid container component="main">
       <Grid item>

--- a/client/src/pages/Dashboard/profile/profileNav/ProfileNav.tsx
+++ b/client/src/pages/Dashboard/profile/profileNav/ProfileNav.tsx
@@ -19,11 +19,6 @@ export default function ProfileNav(): JSX.Element {
     setSelectedIndex(index);
   };
 
-  useEffect(() => {
-    console.log('USE EFFECT');
-    setSelectedIndex(0);
-  }, []);
-
   const profileMenuItems = [
     { link: 'edit profile', route: '/profile', icon: <EditIcon className={classes.icon} /> },
     { link: 'profile photo', route: '/profile/profile-photo', icon: <PhotoCameraIcon className={classes.icon} /> },

--- a/client/src/pages/Dashboard/profile/profileNav/ProfileNav.tsx
+++ b/client/src/pages/Dashboard/profile/profileNav/ProfileNav.tsx
@@ -1,0 +1,56 @@
+import List from '@material-ui/core/List';
+import ListItem from '@material-ui/core/ListItem';
+import { Link } from 'react-router-dom';
+import useStyles from './useStyles';
+import React from 'react';
+import EditIcon from '@material-ui/icons/Edit';
+import { Typography } from '@material-ui/core';
+import PaymentIcon from '@material-ui/icons/PaymentSharp';
+import SecurityIcon from '@material-ui/icons/Security';
+import SettingsIcon from '@material-ui/icons/Settings';
+import PhotoCameraIcon from '@material-ui/icons/PhotoCamera';
+import { useEffect } from 'react';
+
+export default function ProfileNav(): JSX.Element {
+  const classes = useStyles();
+  const [selectedIndex, setSelectedIndex] = React.useState(0);
+
+  const handleListItemClick = (event: React.MouseEvent<HTMLDivElement, MouseEvent>, index: number) => {
+    setSelectedIndex(index);
+  };
+
+  useEffect(() => {
+    console.log('USE EFFECT');
+    setSelectedIndex(0);
+  }, []);
+
+  const profileMenuItems = [
+    { link: 'edit profile', route: '/profile', icon: <EditIcon className={classes.icon} /> },
+    { link: 'profile photo', route: '/profile/profile-photo', icon: <PhotoCameraIcon className={classes.icon} /> },
+    { link: 'payment', route: '/profile/payment', icon: <PaymentIcon className={classes.icon} /> },
+    { link: 'security', route: '/profile/security', icon: <SecurityIcon className={classes.icon} /> },
+    { link: 'settings', route: '/profile/settings', icon: <SettingsIcon className={classes.icon} /> },
+  ];
+
+  const profileMenu = (
+    <List className={classes.profileMenu}>
+      {profileMenuItems.map((item, index) => (
+        <ListItem
+          button
+          component={(props) => <Link {...props} to={item.route} />}
+          key={index}
+          dense={true}
+          classes={{ selected: classes.listItemSelected }}
+          className={classes.listItem}
+          selected={selectedIndex === index}
+          onClick={(event: React.MouseEvent<HTMLDivElement, MouseEvent>) => handleListItemClick(event, index)}
+        >
+          <Typography className={classes.linkText}> {item.link} </Typography>
+          {item.icon}
+        </ListItem>
+      ))}
+    </List>
+  );
+
+  return <div>{profileMenu}</div>;
+}

--- a/client/src/pages/Dashboard/profile/profileNav/useStyles.ts
+++ b/client/src/pages/Dashboard/profile/profileNav/useStyles.ts
@@ -1,0 +1,41 @@
+import { makeStyles } from '@material-ui/core/styles';
+import { theme } from '../../../../themes/theme';
+
+const useStyles = makeStyles(() => ({
+  profileMenu: {
+    marginTop: theme.spacing(6),
+    marginLeft: theme.spacing(6),
+    [theme.breakpoints.down('sm')]: {
+      marginTop: 0,
+      marginLeft: 0,
+    },
+  },
+  profileLink: {
+    fontSize: 12,
+    textTransform: 'capitalize',
+    textDecoration: 'none',
+    color: '#000000',
+    fontWeight: 600,
+    paddingTop: '0 !important',
+  },
+  listItem: {
+    opacity: '0.3',
+  },
+  listItemSelected: {
+    backgroundColor: '#fafafa !important',
+    opacity: '1',
+  },
+  icon: {
+    marginTop: theme.spacing(2),
+    [theme.breakpoints.up('md')]: {
+      display: 'none',
+    },
+  },
+  linkText: {
+    [theme.breakpoints.down('sm')]: {
+      display: 'none',
+    },
+  },
+}));
+
+export default useStyles;

--- a/client/src/pages/Dashboard/profile/profilePhoto/ProfilePhoto.tsx
+++ b/client/src/pages/Dashboard/profile/profilePhoto/ProfilePhoto.tsx
@@ -1,0 +1,25 @@
+import Grid from '@material-ui/core/Grid';
+import CircularProgress from '@material-ui/core/CircularProgress';
+import { useAuth } from '../../../../context/useAuthContext';
+import { useHistory } from 'react-router-dom';
+
+export default function ProfilePhoto(): JSX.Element {
+  const { loggedInUser } = useAuth();
+
+  const history = useHistory();
+
+  if (loggedInUser === undefined) return <CircularProgress />;
+  if (!loggedInUser) {
+    history.push('/login');
+    // loading for a split seconds until history.push works
+    return <CircularProgress />;
+  }
+
+  return (
+    <Grid container component="main">
+      <Grid item>
+        <h2>profile photo</h2>
+      </Grid>
+    </Grid>
+  );
+}

--- a/client/src/pages/Dashboard/profile/profilePhoto/ProfilePhoto.tsx
+++ b/client/src/pages/Dashboard/profile/profilePhoto/ProfilePhoto.tsx
@@ -1,20 +1,6 @@
 import Grid from '@material-ui/core/Grid';
-import CircularProgress from '@material-ui/core/CircularProgress';
-import { useAuth } from '../../../../context/useAuthContext';
-import { useHistory } from 'react-router-dom';
 
 export default function ProfilePhoto(): JSX.Element {
-  const { loggedInUser } = useAuth();
-
-  const history = useHistory();
-
-  if (loggedInUser === undefined) return <CircularProgress />;
-  if (!loggedInUser) {
-    history.push('/login');
-    // loading for a split seconds until history.push works
-    return <CircularProgress />;
-  }
-
   return (
     <Grid container component="main">
       <Grid item>

--- a/client/src/pages/Dashboard/profile/security/Security.tsx
+++ b/client/src/pages/Dashboard/profile/security/Security.tsx
@@ -1,0 +1,25 @@
+import Grid from '@material-ui/core/Grid';
+import CircularProgress from '@material-ui/core/CircularProgress';
+import { useAuth } from '../../../../context/useAuthContext';
+import { useHistory } from 'react-router-dom';
+
+export default function Security(): JSX.Element {
+  const { loggedInUser } = useAuth();
+
+  const history = useHistory();
+
+  if (loggedInUser === undefined) return <CircularProgress />;
+  if (!loggedInUser) {
+    history.push('/login');
+    // loading for a split seconds until history.push works
+    return <CircularProgress />;
+  }
+
+  return (
+    <Grid container component="main">
+      <Grid item>
+        <h2>security</h2>
+      </Grid>
+    </Grid>
+  );
+}

--- a/client/src/pages/Dashboard/profile/security/Security.tsx
+++ b/client/src/pages/Dashboard/profile/security/Security.tsx
@@ -1,20 +1,6 @@
 import Grid from '@material-ui/core/Grid';
-import CircularProgress from '@material-ui/core/CircularProgress';
-import { useAuth } from '../../../../context/useAuthContext';
-import { useHistory } from 'react-router-dom';
 
 export default function Security(): JSX.Element {
-  const { loggedInUser } = useAuth();
-
-  const history = useHistory();
-
-  if (loggedInUser === undefined) return <CircularProgress />;
-  if (!loggedInUser) {
-    history.push('/login');
-    // loading for a split seconds until history.push works
-    return <CircularProgress />;
-  }
-
   return (
     <Grid container component="main">
       <Grid item>

--- a/client/src/pages/Dashboard/profile/settings/Settings.tsx
+++ b/client/src/pages/Dashboard/profile/settings/Settings.tsx
@@ -1,0 +1,25 @@
+import Grid from '@material-ui/core/Grid';
+import CircularProgress from '@material-ui/core/CircularProgress';
+import { useAuth } from '../../../../context/useAuthContext';
+import { useHistory } from 'react-router-dom';
+
+export default function Settings(): JSX.Element {
+  const { loggedInUser } = useAuth();
+
+  const history = useHistory();
+
+  if (loggedInUser === undefined) return <CircularProgress />;
+  if (!loggedInUser) {
+    history.push('/login');
+    // loading for a split seconds until history.push works
+    return <CircularProgress />;
+  }
+
+  return (
+    <Grid container component="main">
+      <Grid item>
+        <h2>settings</h2>
+      </Grid>
+    </Grid>
+  );
+}

--- a/client/src/pages/Dashboard/profile/settings/Settings.tsx
+++ b/client/src/pages/Dashboard/profile/settings/Settings.tsx
@@ -1,20 +1,6 @@
 import Grid from '@material-ui/core/Grid';
-import CircularProgress from '@material-ui/core/CircularProgress';
-import { useAuth } from '../../../../context/useAuthContext';
-import { useHistory } from 'react-router-dom';
 
 export default function Settings(): JSX.Element {
-  const { loggedInUser } = useAuth();
-
-  const history = useHistory();
-
-  if (loggedInUser === undefined) return <CircularProgress />;
-  if (!loggedInUser) {
-    history.push('/login');
-    // loading for a split seconds until history.push works
-    return <CircularProgress />;
-  }
-
   return (
     <Grid container component="main">
       <Grid item>

--- a/client/src/pages/Dashboard/profile/useStyles.ts
+++ b/client/src/pages/Dashboard/profile/useStyles.ts
@@ -1,0 +1,35 @@
+import { makeStyles } from '@material-ui/core/styles';
+import { theme } from '../../../themes/theme';
+
+const useStyles = makeStyles(() => ({
+  contentContainer: {
+    minHeight: '50vh',
+    minWidth: '50vw',
+    backgroundColor: 'white',
+    boxShadow: '1px 1px 15px rgb(0,0,0,0.1)',
+    borderRadius: theme.shape.borderRadius,
+    [theme.breakpoints.down('sm')]: {
+      width: '95vw',
+    },
+  },
+  viewContainer: {
+    height: '80vh',
+    width: '80vw',
+    display: 'flex',
+    justifyContent: 'center',
+    alignitems: 'center',
+    marginTop: theme.spacing(10),
+    [theme.breakpoints.down('sm')]: {
+      width: '90vw',
+      marginTop: theme.spacing(4),
+    },
+  },
+  navContainer: {
+    height: '20vh',
+    width: '85vw',
+    backgroundColor: 'red',
+    marginLeft: '17vw',
+  },
+}));
+
+export default useStyles;


### PR DESCRIPTION
### What this PR does (required):
- Address ticket 6
#6 

-Profile skeleton added with profile navigation and content pages with templates
-Implemented responsive navigation using icons

### Screenshots / Videos (front-end only):
- 
![Screenshot (148)](https://user-images.githubusercontent.com/77120652/141503788-45bd82a0-cd85-4587-82ba-0d88ecf9ea38.png)
![Screenshot (149)](https://user-images.githubusercontent.com/77120652/141503790-8d22a1f0-30eb-4013-bffe-2c7de7fd25df.png)
![Screenshot (150)](https://user-images.githubusercontent.com/77120652/141503791-ab65ae54-e67e-49f1-b34c-cc2387bcad71.png)
Post at least one screenshot to show the feature in action. **Only required in front-end work**

### Any information needed to test this feature (required):
- Login and navigate to profile section using avatar
- Click a link in the profile navigation to navigate the various views
- Resize page for responsive navigation

### Any issues with the current functionality (optional):
N/A